### PR TITLE
'.concat' change and potential line cutoff change

### DIFF
--- a/on_fire.py
+++ b/on_fire.py
@@ -46,11 +46,7 @@ for i, jsons in enumerate(jsonlist):
     df = pd.json_normalize(jsons, record_path='data') #normalize all jsons into dfs
     dfs.append(df)
 
-if len(dfs) > 1:
-    mergedpd = pd.concat(dfs, ignore_index=True) 
-else:
-    mergedpd = dfs[0] #use for low volume games like in season tournament days
-    
+mergedpd = pd.concat(dfs, ignore_index=True) #this will also work on days where there is only one dataframe to take in; best to use this instead of "mergedpd = dfs[0]" given that we want to modify a "full" dataframe rather than a copy of it 
 
 gms = league.teams #fetch all team names
 

--- a/on_fire.py
+++ b/on_fire.py
@@ -152,7 +152,7 @@ if mergedpd.empty is False:
 
 
     top = mergedpd.sort_values(by='ZSUM', ascending=False)
-    if len(top.index) < 20:
+    if len(top.index) < 30:
         topprintout = printout(top, 5)
     else:
         topprintout = printout(top, 10)


### PR DESCRIPTION
A couple changes here:
1) The pd.concat criteria is simplified; I suddenly learned today that this function actually works fine even when there's only one dataframe or null dataframes! To simplify any potential issues with using `dfs[0]` (this raises `SettingWithCopyWarning` in the case of days like today where there's only one dataframe), we now use pd.concat no matter what the length of the df list is. 

2) The bigger change would be to raise the minimum line requirement to print ten lines (in the case of the "best" list) to 30 players rather than 20. We just got our first trial day today where there were only two games with BOS vs ATL and MKE vs NoLa and we still made the cut-off to have ten lines printed (another surprise of this low volume day!). We'd want to emphasize the quality of the kind of lines you'd see on higher volume days; this change is more subjective but I think it would be fair for display purposes in terms of being able to give the best lines weight no matter what day it is. Not merging this yet though until I get some more feedback. 