### PR TITLE
Lowering FTARZ weight to 0.80

### DIFF
--- a/on_fire.py
+++ b/on_fire.py
@@ -127,7 +127,7 @@ if mergedpd.empty is False:
     mergedpd['BLKZ'] = (((mergedpd['blk']-0.6413044)/0.5216844)*0.80)
     mergedpd['PTSZ'] = ((mergedpd['pts']-16.192476)/5.956778)
     mergedpd['FGARZ'] = (((mergedpd['FGAR']-(-0.03505124))/0.65614770)*0.90)
-    mergedpd['FTARZ'] = (((mergedpd['FTAR']-0.02214733)/0.28761030)*0.90)
+    mergedpd['FTARZ'] = (((mergedpd['FTAR']-0.02214733)/0.28761030)*0.80)
 
     col_list = list(mergedpd)
     zcols = col_list[55:64] #rebz through ftarz


### PR DESCRIPTION
This change lowers the FTAR Z weight to 0.80. Assuming we used .90, Zion's line from 3/28 against Milwaukee would have been considered the "worst" due to going 10/16 from the line. Although it would be fair overall for him to have his score lowered due to the low ft accuracy, at the same time we'd want to place weight on lines that were consistently poor across multiple categories rather than placing more weight on a CAT that can be very variable. This change lowers the FTAR weight while keeping the FGAR Z weight at 0.90 since FG% volume calculations don't punish decreases in accuracy as much by default especially when players take far more shots there. 