### PR TITLE
Add bench and IR filter

### DIFF
--- a/on_fire.py
+++ b/on_fire.py
@@ -133,7 +133,9 @@ if mergedpd.empty is False:
     mergedpd['GM'] = mergedpd['PlayerName'].map(playerdict)
     mergedpd['Status'] = mergedpd['PlayerName'].map(statusdict)
     mergedpd = mergedpd.dropna(subset=["GM"])
-    mergedpd = mergedpd.query("Status != 'BE'")
+    mergedpd = mergedpd.query("Status != 'BE'")  
+    mergedpd = mergedpd.query("Status != 'IR'")
+
 
 
     mergedpd['FGAR'] = (mergedpd['fgm']-(0.4834302*mergedpd['fga'])) 

--- a/on_fire.py
+++ b/on_fire.py
@@ -54,17 +54,30 @@ playerslist = []
 for i in range(len(gms)):
     players = league.teams[i].roster #get roster via index obtained with len(); each gm number corresponds to their respective roster 
     playerslist.append(players) #each entry is a list of rosters; this will be separated when we use explode() with Pandas  
+
+def getstatus(playerlist):
+    for i, lists in enumerate(playerlist):
+        for z, players in enumerate(lists):
+            status = league.teams[i].roster[z].lineupSlot
+            players = str(players)
+            players = players + ', ' + status
+            lists[z] = players
+
+getstatus(playerslist)
     
 df = pd.DataFrame((zip(gms, playerslist)), 
     columns = ['GM', 'Player'])
 
 df2 = df.explode('Player')
 df2 = df2.astype(str)
+df2[['Player', 'Status']] = df2['Player'].str.split(', ', n=1, expand=True)
 df2['GM'] = df2['GM'].str.replace('Team(', '')
 df2['GM'] = df2['GM'].str.replace(')', '')
 df2['Player'] = df2['Player'].str.replace('Player(', '')
 df2['Player'] = df2['Player'].str.replace(')', '')
 playerdict = df2.set_index('Player')['GM'].to_dict()
+statusdict = df2.set_index('Player')['Status'].to_dict()
+
 
 #create emoji criteria for "mindblowing stats"
 def zcheck(bdldf, zcolumn, x) -> str: 
@@ -118,7 +131,9 @@ def printout(bdldf, maxlines) -> str:
 if mergedpd.empty is False:
     mergedpd['PlayerName'] = mergedpd['player.first_name'] + " " + mergedpd['player.last_name']
     mergedpd['GM'] = mergedpd['PlayerName'].map(playerdict)
+    mergedpd['Status'] = mergedpd['PlayerName'].map(statusdict)
     mergedpd = mergedpd.dropna(subset=["GM"])
+    mergedpd = mergedpd.query("Status != 'BE'")
 
 
     mergedpd['FGAR'] = (mergedpd['fgm']-(0.4834302*mergedpd['fga'])) 


### PR DESCRIPTION
Using ESPN API's ability to fetch player statuses, this adds a filter to exclude any players who were benched or on the IR from being in the top/worst lists or in the graph (if the latter becomes an official feature). Although we were technically filtering out injured players before, another element to consider is that teams may not be able to activate an IR player in time before they play, which means that a player could be listed as the "best" for the night without the team actually reaping any of the rewards from his performance. This also applies to players who were left benched, either accidentally or sometimes intentionally to avoid losing in CATs such as FT% or TOs. As the goal of On Fire is to display which teams benefitted or got left out in a fantasy league, this makes our final snapshot of how teams were left for the night much more accurate. 

As a note, the > 0 minutes filter will also remain given that players may not be placed in the IR in time before games start and for cases where players get a DNP (the latter being very rare in fantasy since they generally won't be picked up in the first place, but technically possible). 